### PR TITLE
Fix mouse glitch

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -184,16 +184,17 @@ var undo_button = document.getElementById("tb_undo")
 var redo_button = document.getElementById("tb_redo")
 undo_button.addEventListener(ondown_key, e => {
   e.preventDefault();
-  if (timer) {
-    clearInterval(timer);
-    count = 0;
-  }
-  timer = setInterval(() => {
+  new_timer = setInterval(() => {
     count++;
     if(count>5){
       pu.undo();
     }
   }, 80);
+  if (new_timer !== timer) {
+    clearInterval(timer);
+    count = 0;
+  }
+  timer = new_timer;
 }, {passive: false});
 
 undo_button.addEventListener(onup_key, e => {
@@ -212,16 +213,17 @@ undo_button.addEventListener(onleave_key, e => {
 
 redo_button.addEventListener(ondown_key, e => {
   e.preventDefault();
-  if (timer) {
-    clearInterval(timer);
-    count = 0;
-  }
-  timer = setInterval(() => {
+  new_timer = setInterval(() => {
     count++;
     if(count>5){
       pu.redo();
     }
   }, 80);
+  if (new_timer !== timer) {
+    clearInterval(timer);
+    count = 0;
+  }
+  timer = new_timer;
 }, {passive: false});
 
 redo_button.addEventListener(onup_key, e => {

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -184,12 +184,16 @@ var undo_button = document.getElementById("tb_undo")
 var redo_button = document.getElementById("tb_redo")
 undo_button.addEventListener(ondown_key, e => {
   e.preventDefault();
+  if (timer) {
+    clearInterval(timer);
+    count = 0;
+  }
   timer = setInterval(() => {
     count++;
-    if(count>20){
+    if(count>5){
       pu.undo();
     }
-  }, 20);
+  }, 80);
 }, {passive: false});
 
 undo_button.addEventListener(onup_key, e => {
@@ -208,12 +212,16 @@ undo_button.addEventListener(onleave_key, e => {
 
 redo_button.addEventListener(ondown_key, e => {
   e.preventDefault();
+  if (timer) {
+    clearInterval(timer);
+    count = 0;
+  }
   timer = setInterval(() => {
     count++;
-    if(count>20){
+    if(count>5){
       pu.redo();
     }
-  }, 20);
+  }, 80);
 }, {passive: false});
 
 redo_button.addEventListener(onup_key, e => {


### PR DESCRIPTION
In a youtube video [link](https://youtu.be/emH5qSvPTes?t=732), Cracking the Cryptic had a mouse glitch, where the undo button didn't stop, it kept going, whatever the user did. Basically, when holding the undo button and at the same time pressing the right mouse button, the mousedown event was triggered again in a way that rewrote the timer variable hence not allowing the previous setInterval to be cleared anymore. A small if clause should fix this. I also took the liberty to slow down the undo and redo buttons 4x, because I think those were blazingly fast before.